### PR TITLE
feat: inline diffs for git changes via CodeMirror merge view

### DIFF
--- a/IDE_BUILD_PLAN.md
+++ b/IDE_BUILD_PLAN.md
@@ -1,6 +1,6 @@
 # Custom AI-Integrated IDE — Build Plan
 > **Project codename:** *aIDE*
-> **Last updated:** March 27, 2026
+> **Last updated:** March 28, 2026
 > **Status:** Active development (Phase 2 in progress)
 
 ---
@@ -96,7 +96,7 @@ A desktop IDE built specifically for the workflow of running multiple AI coding 
 - [ ] Plugin system with npm-based distribution
 - [ ] Broad language support — the goal is to support all languages via individually installable language packs. Use off-the-shelf LSP servers and linters where available; only build custom integrations when necessary. No language tooling installed by default — user installs what they need
 - [ ] Chrome extension support (limited — see Known Hard Problems)
-- [ ] AI-powered inline diff review in editor
+- [x] AI-powered inline diff review in editor (CodeMirror `@codemirror/merge` unified view with accept/reject, Cmd+Shift+D toggle, git HEAD comparison)
 - [ ] Agent permission system — configurable guardrails per workspace via `.agentconfig` (file access scope, shell command scope, network scope, package installation). Default: "ask before running destructive commands." Requires approval UI in agent panel that surfaces to workspace tab even when in another workspace
 - [ ] Workspace onboarding wizard — auto-detect project type, Python interpreter, `package.json` scripts, `CLAUDE.md`/`.agentconfig`, git remote, dev server command/port. Surface as a checklist of suggestions on first open
 - [ ] Agent project memory — track which files agent has seen, maintain auto-generated `project-summary.md`, surface "unseen files" in agent panel for context priming

--- a/packages/main/src/gitDiff.ts
+++ b/packages/main/src/gitDiff.ts
@@ -1,0 +1,47 @@
+import { ipcMain } from 'electron'
+import simpleGit from 'simple-git'
+import { IpcChannels } from '@aide/shared'
+
+let currentRoot: string | null = null
+
+/**
+ * Set the workspace root used for git diff operations.
+ */
+export function setDiffRoot(rootPath: string | null): void {
+  currentRoot = rootPath
+}
+
+/**
+ * Get the original (HEAD) content of a file from git.
+ * Returns the file content as it exists in the HEAD commit,
+ * or null if the file is untracked / not in HEAD.
+ */
+async function getOriginalContent(rootPath: string, absolutePath: string): Promise<string | null> {
+  try {
+    const git = simpleGit(rootPath)
+    const isRepo = await git.checkIsRepo()
+    if (!isRepo) return null
+
+    // Compute the relative path from the repo root
+    const relativePath = absolutePath.startsWith(rootPath + '/')
+      ? absolutePath.slice(rootPath.length + 1)
+      : absolutePath
+
+    const content = await git.show([`HEAD:${relativePath}`])
+    return content
+  } catch {
+    // File doesn't exist in HEAD (new/untracked file) or other error
+    return null
+  }
+}
+
+/**
+ * Register IPC handlers for git diff operations.
+ */
+export function registerGitDiffHandlers(): void {
+  ipcMain.handle(IpcChannels.GIT_DIFF_ORIGINAL, async (_event, filePath: string) => {
+    if (!currentRoot) return { content: null }
+    const content = await getOriginalContent(currentRoot, filePath)
+    return { content }
+  })
+}

--- a/packages/main/src/index.ts
+++ b/packages/main/src/index.ts
@@ -19,6 +19,7 @@ import { detectTasks, generateTasksFile, hasTasksFile } from './taskAutoDetect'
 import { WorkspaceRegistry } from './workspaceRegistry'
 import { saveWorkspaceState, loadWorkspaceState, saveTerminalState, loadTerminalState } from './stateSerializer'
 import { BrowserPaneManager } from './browserPaneManager'
+import { registerGitDiffHandlers, setDiffRoot } from './gitDiff'
 
 const store = new Store<AppSettings>({ defaults: DEFAULT_SETTINGS })
 const workspaceRegistry = new WorkspaceRegistry()
@@ -282,6 +283,7 @@ async function activateWorkspace(id: string): Promise<void> {
     }
 
     const getWc = () => contentView?.webContents ?? null
+    setDiffRoot(entry.rootPath)
     await startGitPolling(entry.rootPath, getWc)
     if (activationSeq !== workspaceActivationSeq) {
       stopGitPolling()
@@ -929,6 +931,7 @@ app.whenReady().then(async () => {
 
   const getWebContents = () => contentView?.webContents ?? null
 registerGitStatusHandlers()
+  registerGitDiffHandlers()
   registerWorktreeHandlers(getWebContents, store)
 
   // Notify renderer of crash recovery after window loads

--- a/packages/main/src/preload.ts
+++ b/packages/main/src/preload.ts
@@ -72,6 +72,10 @@ const api: WindowApi = {
     return () => ipcRenderer.removeListener(IpcChannels.GIT_BRANCH_CHANGED, handler)
   },
 
+  // Git diff
+  getGitFileOriginal: (filePath: string): Promise<{ content: string | null }> =>
+    ipcRenderer.invoke(IpcChannels.GIT_DIFF_ORIGINAL, filePath),
+
   // Terminal
   ptyCreate: (opts?: { id?: string; workspaceId?: string; cwd?: string; shell?: string; title?: string }) =>
     ipcRenderer.invoke(IpcChannels.PTY_CREATE, opts),

--- a/packages/renderer/package.json
+++ b/packages/renderer/package.json
@@ -12,6 +12,7 @@
     "@codemirror/lang-markdown": "^6.5.0",
     "@codemirror/lang-python": "^6.2.1",
     "@codemirror/language": "^6.12.3",
+    "@codemirror/merge": "^6.12.1",
     "@codemirror/state": "^6.6.0",
     "@codemirror/theme-one-dark": "^6.1.3",
     "@codemirror/view": "^6.40.0",

--- a/packages/renderer/src/components/panes/EditorPane.tsx
+++ b/packages/renderer/src/components/panes/EditorPane.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useRef, useState, useCallback } from 'react'
 import type { IDockviewPanelProps } from 'dockview-react'
 import { EditorState, StateEffect } from '@codemirror/state'
 import { EditorView, keymap } from '@codemirror/view'
@@ -16,6 +16,8 @@ import { setContext } from '../../lib/ContextKeys'
 import { useEditorStatus } from '../../hooks/useEditorStatus'
 import { useTheme } from '../../hooks/useTheme'
 import { showToast } from '../Toast'
+import { diffCompartment, toggleInlineDiff, isInlineDiffActive } from '../../lib/editorInlineDiff'
+import '../../styles/inline-diff.css'
 
 interface EditorPaneParams {
   filePath: string
@@ -52,6 +54,7 @@ export function EditorPane({ params, api }: IDockviewPanelProps<EditorPaneParams
   const setStatusRef = useRef(setStatus)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  const [diffActive, setDiffActive] = useState(false)
 
   const filePath = params.filePath
 
@@ -116,6 +119,7 @@ export function EditorPane({ params, api }: IDockviewPanelProps<EditorPaneParams
               publishContent(filePath, update.state.doc.toString())
             }
           }),
+          diffCompartment.of([]),
           keymap.of([
             {
               key: 'Mod-s',
@@ -136,6 +140,16 @@ export function EditorPane({ params, api }: IDockviewPanelProps<EditorPaneParams
                 const enabled = toggleWrap()
                 view.dispatch({
                   effects: wrapCompartment.reconfigure(getWrapExtension(enabled)),
+                })
+                return true
+              },
+            },
+            {
+              key: 'Mod-Shift-d',
+              run: (view) => {
+                toggleInlineDiff(view, filePath).then((enabled) => {
+                  setDiffActive(enabled)
+                  showToast(enabled ? 'Inline diff enabled' : 'Inline diff disabled')
                 })
                 return true
               },
@@ -335,6 +349,21 @@ export function EditorPane({ params, api }: IDockviewPanelProps<EditorPaneParams
     return unsub
   }, [filePath, api])
 
+  // Listen for external toggle-inline-diff events (e.g., command palette)
+  useEffect(() => {
+    const view = viewRef.current
+    if (!view) return
+
+    const handler = () => {
+      toggleInlineDiff(view, filePath).then((enabled) => {
+        setDiffActive(enabled)
+        showToast(enabled ? 'Inline diff enabled' : 'Inline diff disabled')
+      })
+    }
+    window.addEventListener('aide:toggle-inline-diff', handler)
+    return () => window.removeEventListener('aide:toggle-inline-diff', handler)
+  }, [filePath, loading])
+
   // Push cursor status when this panel becomes active
   useEffect(() => {
     const disposable = api.onDidActiveChange(({ isActive }) => {
@@ -363,9 +392,27 @@ export function EditorPane({ params, api }: IDockviewPanelProps<EditorPaneParams
     )
   }
 
+  const handleDiffBadgeClick = useCallback(() => {
+    const view = viewRef.current
+    if (!view) return
+    toggleInlineDiff(view, filePath).then((enabled) => {
+      setDiffActive(enabled)
+      showToast(enabled ? 'Inline diff enabled' : 'Inline diff disabled')
+    })
+  }, [filePath])
+
   return (
     <div className="editor-pane">
       {loading && <div className="editor-pane__loading">Loading…</div>}
+      {diffActive && (
+        <div
+          className="editor-pane__diff-badge"
+          onClick={handleDiffBadgeClick}
+          title="Click to close diff view (Cmd+Shift+D)"
+        >
+          DIFF
+        </div>
+      )}
       <div
         ref={hostRef}
         className="editor-pane__cm-host"

--- a/packages/renderer/src/lib/defaultCommands.ts
+++ b/packages/renderer/src/lib/defaultCommands.ts
@@ -80,6 +80,11 @@ export function registerDefaultCommands(dockviewApi: DockviewApi): void {
     () => showToast('Symbol search requires LSP (coming in Phase 3)'),
   )
 
+  registerCommand(
+    { id: 'editor.toggleInlineDiff', label: 'Toggle Inline Diff', category: 'Editor' },
+    () => window.dispatchEvent(new CustomEvent('aide:toggle-inline-diff')),
+  )
+
   // Full .aide project initialization
   registerCommand(
     { id: 'aide.init', label: 'Initialize Project', category: 'aIDE' },

--- a/packages/renderer/src/lib/defaultKeybindings.ts
+++ b/packages/renderer/src/lib/defaultKeybindings.ts
@@ -10,6 +10,7 @@ export const defaultKeybindings: KeybindingRule[] = [
   { key: 'Cmd+Shift+\\', command: 'editor.splitHorizontal' },
   { key: 'Cmd+T', command: 'editor.symbolSearch' },
   { key: 'Cmd+/', command: 'editor.toggleComment', when: 'editorInFocus' },
+  { key: 'Cmd+Shift+D', command: 'editor.toggleInlineDiff', when: 'editorInFocus' },
   { key: 'Cmd+K Cmd+C', command: 'editor.commentLine', when: 'editorInFocus' },
   { key: 'Cmd+K Cmd+U', command: 'editor.uncommentLine', when: 'editorInFocus' },
 

--- a/packages/renderer/src/lib/editorInlineDiff.ts
+++ b/packages/renderer/src/lib/editorInlineDiff.ts
@@ -1,0 +1,89 @@
+import { Compartment } from '@codemirror/state'
+import type { Extension } from '@codemirror/state'
+import { EditorView } from '@codemirror/view'
+import { unifiedMergeView, acceptChunk, rejectChunk, getOriginalDoc } from '@codemirror/merge'
+
+/** Compartment used to toggle inline diff on/off. */
+export const diffCompartment = new Compartment()
+
+/**
+ * Create the unified merge view extension configured for aIDE.
+ * Shows deleted lines inline, gutter indicators, and accept/reject controls.
+ */
+function createMergeExtension(original: string): Extension {
+  return unifiedMergeView({
+    original,
+    highlightChanges: true,
+    gutter: true,
+    syntaxHighlightDeletions: true,
+    mergeControls: true,
+    allowInlineDiffs: true,
+  })
+}
+
+/**
+ * Enable inline diff mode by comparing against the given original content.
+ * The current editor content is treated as the "new" version.
+ */
+export function enableInlineDiff(view: EditorView, originalContent: string): void {
+  view.dispatch({
+    effects: diffCompartment.reconfigure(createMergeExtension(originalContent)),
+  })
+}
+
+/**
+ * Disable inline diff mode and return to normal editing.
+ */
+export function disableInlineDiff(view: EditorView): void {
+  view.dispatch({
+    effects: diffCompartment.reconfigure([]),
+  })
+}
+
+/**
+ * Check if inline diff is currently active.
+ */
+export function isInlineDiffActive(view: EditorView): boolean {
+  try {
+    getOriginalDoc(view.state)
+    return true
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Toggle inline diff on/off. When enabling, fetches the original
+ * content from git via the preload API.
+ * Returns true if diff was enabled, false if disabled.
+ */
+export async function toggleInlineDiff(view: EditorView, filePath: string): Promise<boolean> {
+  if (isInlineDiffActive(view)) {
+    disableInlineDiff(view)
+    return false
+  }
+
+  const result = await window.api.getGitFileOriginal(filePath)
+  if (result.content === null) {
+    // File is untracked or not in a git repo — use empty string
+    // so all lines show as "added"
+    enableInlineDiff(view, '')
+  } else {
+    enableInlineDiff(view, result.content)
+  }
+  return true
+}
+
+/**
+ * Accept the change chunk at the cursor position.
+ */
+export function acceptCurrentChunk(view: EditorView): boolean {
+  return acceptChunk(view)
+}
+
+/**
+ * Reject the change chunk at the cursor position (revert to original).
+ */
+export function rejectCurrentChunk(view: EditorView): boolean {
+  return rejectChunk(view)
+}

--- a/packages/renderer/src/styles/inline-diff.css
+++ b/packages/renderer/src/styles/inline-diff.css
@@ -1,0 +1,115 @@
+/* ─── Inline Diff Styling ─────────────────────────────────── */
+
+/* Gutter indicator for changed chunks */
+.cm-editor .cm-changedLine .cm-changeGutter {
+  width: 3px;
+}
+
+/* Override merge view colors for dark theme */
+[data-theme="one-dark"] .cm-editor {
+  /* Deleted lines (shown as inserted readonly blocks) */
+  --merge-delete-bg: rgba(224, 108, 117, 0.12);
+  --merge-delete-gutter: #e06c75;
+  --merge-insert-bg: rgba(152, 195, 121, 0.12);
+  --merge-insert-gutter: #98c379;
+}
+
+[data-theme="one-light"] .cm-editor {
+  --merge-delete-bg: rgba(228, 86, 73, 0.10);
+  --merge-delete-gutter: #e45649;
+  --merge-insert-bg: rgba(80, 161, 79, 0.10);
+  --merge-insert-gutter: #50a14f;
+}
+
+/* Deleted chunks (original content that was removed) */
+.cm-editor .cm-deletedChunk {
+  background-color: var(--merge-delete-bg, rgba(224, 108, 117, 0.12));
+  border-left: none;
+}
+
+.cm-editor .cm-deletedChunk .cm-deletedLine {
+  background-color: transparent;
+  color: var(--text-secondary);
+  opacity: 0.8;
+}
+
+/* Inserted/changed lines in current document */
+.cm-editor .cm-changedLine {
+  background-color: var(--merge-insert-bg, rgba(152, 195, 121, 0.12));
+}
+
+/* Gutter markers for changes */
+.cm-editor .cm-changeGutter .cm-gutterElement {
+  padding: 0;
+  min-width: 4px;
+  width: 4px;
+}
+
+/* Gutter marker for inserted lines */
+.cm-editor .cm-changeGutter .cm-changedLineGutter {
+  background-color: var(--merge-insert-gutter, #98c379);
+}
+
+/* Gutter marker for deleted lines */
+.cm-editor .cm-changeGutter .cm-deletedLineGutter {
+  background-color: var(--merge-delete-gutter, #e06c75);
+}
+
+/* Inline character-level changes */
+.cm-editor .cm-changedText {
+  background-color: rgba(152, 195, 121, 0.25);
+  border-radius: 2px;
+}
+
+.cm-editor .cm-deletedChunk .cm-changedText {
+  background-color: rgba(224, 108, 117, 0.25);
+  border-radius: 2px;
+}
+
+/* Accept/Reject buttons styling */
+.cm-editor .cm-mergeControls {
+  display: flex;
+  gap: 2px;
+  padding: 0 4px;
+  align-items: center;
+}
+
+.cm-editor .cm-mergeControls button {
+  background: none;
+  border: 1px solid var(--border-subtle, #2e333b);
+  border-radius: 3px;
+  color: var(--text-secondary, #7f8694);
+  cursor: pointer;
+  font-size: 11px;
+  padding: 1px 6px;
+  line-height: 1.4;
+  transition: background-color 0.1s, color 0.1s;
+}
+
+.cm-editor .cm-mergeControls button:hover {
+  background-color: var(--bg-hover, rgba(255, 255, 255, 0.04));
+  color: var(--text-primary, #abb2bf);
+}
+
+/* Diff status bar indicator */
+.editor-pane__diff-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 1px 8px;
+  border-radius: 3px;
+  font-size: 11px;
+  color: var(--text-info, hsl(219, 79%, 66%));
+  background-color: rgba(82, 139, 255, 0.1);
+  cursor: pointer;
+  user-select: none;
+  position: absolute;
+  top: 4px;
+  right: 12px;
+  z-index: 5;
+  transition: background-color 0.15s;
+}
+
+.editor-pane__diff-badge:hover {
+  background-color: rgba(82, 139, 255, 0.2);
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -63,6 +63,9 @@ export const IpcChannels = {
   GIT_STATUS_CHANGED: 'git:status-changed',
   GIT_BRANCH_CHANGED: 'git:branch-changed',
 
+  // Git diff
+  GIT_DIFF_ORIGINAL: 'git:diff-original',
+
   // Terminal / PTY
   PTY_CREATE: 'pty:create',
   PTY_DATA_IN: 'pty:data-in',
@@ -559,6 +562,9 @@ export interface WindowApi {
   getGitStatus: () => Promise<GitStatusResult | null>
   onGitStatusChanged: (callback: (status: GitStatusResult) => void) => () => void
   onGitBranchChanged: (callback: (branch: string) => void) => () => void
+
+  // Git diff
+  getGitFileOriginal: (filePath: string) => Promise<{ content: string | null }>
 
   // Terminal
   ptyCreate: (opts?: { id?: string; workspaceId?: string; cwd?: string; shell?: string; title?: string }) => Promise<{ id: string; scrollback: string }>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -135,6 +135,9 @@ importers:
       '@codemirror/language':
         specifier: ^6.12.3
         version: 6.12.3
+      '@codemirror/merge':
+        specifier: ^6.12.1
+        version: 6.12.1
       '@codemirror/state':
         specifier: ^6.6.0
         version: 6.6.0
@@ -337,6 +340,9 @@ packages:
 
   '@codemirror/lint@6.9.5':
     resolution: {integrity: sha512-GElsbU9G7QT9xXhpUg1zWGmftA/7jamh+7+ydKRuT0ORpWS3wOSP0yT1FOlIZa7mIJjpVPipErsyvVqB9cfTFA==}
+
+  '@codemirror/merge@6.12.1':
+    resolution: {integrity: sha512-GA8hBq2T+IFM0sb5fk8CunTrqOulA3zurJmHtzcU15EMnL8aYpVINfJ5bkfd53M4ikwoew4Y1ydtSaAlk6+B1w==}
 
   '@codemirror/search@6.6.0':
     resolution: {integrity: sha512-koFuNXcDvyyotWcgOnZGmY7LZqEOXZaaxD/j6n18TCLx2/9HieZJ5H6hs1g8FiRxBD0DNfs0nXn17g872RmYdw==}
@@ -3853,6 +3859,14 @@ snapshots:
       '@codemirror/state': 6.6.0
       '@codemirror/view': 6.40.0
       crelt: 1.0.6
+
+  '@codemirror/merge@6.12.1':
+    dependencies:
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.40.0
+      '@lezer/highlight': 1.2.3
+      style-mod: 4.1.3
 
   '@codemirror/search@6.6.0':
     dependencies:


### PR DESCRIPTION
## Summary

- Add inline diff support using `@codemirror/merge`'s `unifiedMergeView` extension, comparing editor content against git HEAD
- Toggle via `Cmd+Shift+D` keybinding or "Toggle Inline Diff" command in the command palette
- Full feature set: deleted lines inline (red), added lines (green), character-level diffs, accept/reject controls per chunk, gutter indicators, syntax-highlighted deletions, theme-aware dark/light styling

## Architecture

**New files:**
- `packages/main/src/gitDiff.ts` — IPC handler to fetch original file content from `git show HEAD:<path>` via `simple-git`
- `packages/renderer/src/lib/editorInlineDiff.ts` — CodeMirror extension wrapper using a `Compartment` to dynamically toggle `unifiedMergeView` on/off
- `packages/renderer/src/styles/inline-diff.css` — Theme-aware styling for diff decorations, gutter markers, accept/reject buttons, and DIFF badge

**Modified files:**
- `packages/shared/src/index.ts` — New `GIT_DIFF_ORIGINAL` IPC channel + `getGitFileOriginal` API method
- `packages/main/src/preload.ts` — Wire up git diff IPC bridge
- `packages/main/src/index.ts` — Register diff handlers + set diff root on workspace activation
- `packages/renderer/src/components/panes/EditorPane.tsx` — Integrate diff compartment, keybinding, event listener, DIFF badge UI
- `packages/renderer/src/lib/defaultCommands.ts` — "Toggle Inline Diff" command for palette
- `packages/renderer/src/lib/defaultKeybindings.ts` — `Cmd+Shift+D` binding

## Design decisions

- **`@codemirror/merge` over custom implementation**: Battle-tested diff algorithm, handles widget decorations for deleted lines, cursor positioning around widgets, scroll sync, syntax highlighting in deleted blocks, and accept/reject controls out of the box
- **Compartment-based toggle**: The diff extension is dormant (empty compartment) until toggled, zero overhead when inactive
- **Generic API**: `enableInlineDiff(view, originalContent)` accepts any string — works for git HEAD diffs now, agent-proposed changes later
- **Untracked files**: When a file has no git HEAD version, diff treats all content as "added" (empty original)

## Test plan

- [ ] Open a file with git changes, press `Cmd+Shift+D` — verify inline diff appears with correct added/deleted highlighting
- [ ] Press `Cmd+Shift+D` again — verify diff view is disabled and editor returns to normal
- [ ] Open command palette (`Cmd+Shift+P`), search "Toggle Inline Diff" — verify command works
- [ ] Click the DIFF badge in top-right — verify it toggles off
- [ ] Open an untracked file, toggle diff — verify all lines shown as added
- [ ] In diff view, click accept/reject buttons on a chunk — verify they work
- [ ] Switch between dark and light themes with diff active — verify colors update
- [ ] Edit the file while diff is active — verify diff updates live
- [ ] Build succeeds: `npx electron-vite build` passes all three bundles (main, preload, renderer)

https://claude.ai/code/session_01QLT8wXFvfdWWvqGTBuhLEk

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added inline diff review to the editor with visual change highlighting
  * Toggle inline diff view using Cmd+Shift+D keyboard shortcut
  * Compare editor content against git repository HEAD version
  * New diff badge indicator shows when diff view is active

<!-- end of auto-generated comment: release notes by coderabbit.ai -->