### PR TITLE
feat: MRU cycling sessions for pane/tab navigation

### DIFF
--- a/IDE_BUILD_PLAN.md
+++ b/IDE_BUILD_PLAN.md
@@ -9,30 +9,33 @@
 - Move worktree storage from `../.aide-worktrees/` to `<repoRoot>/.aide/worktrees/` (match Claude Code convention, add `.aide/` to `.gitignore`)
 - Add `@` prefix in Quick Open (Cmd+P) to go to symbol, `:` prefix to go to line (VS Code-style)
 - Clicking the line number indicator in the status bar should open the go-to-line command palette (`:` mode)
-- Upgrade pane/tab cycling from immediate navigation to a VS Code-style `Ctrl+Tab` switcher overlay with MRU preview and commit-on-release behavior
+- Add a visual switcher overlay for MRU cycling (shows tab/pane list, highlights current selection during cycling session)
+
+### MRU Cycling Sessions (Implemented)
+
+`DockviewNavigation` now supports VS Code-style MRU cycling sessions for both pane and tab navigation:
+
+- On first cycle keystroke: a session begins, the MRU order is frozen, and `recordActivation` is suppressed
+- On subsequent keystrokes (while modifier held): the frozen MRU list is walked in order
+- On modifier key-up (Ctrl/Alt/Meta): the selection is committed, `recordActivation` fires, and the session ends
+- A global `keyup` listener is installed when cycling starts and removed when done
+
+This replaces the previous toggle-most-recent behavior that could only ping-pong between the two most recent entries.
 
 ### Deferred V2: Pane/Tab Switcher Overlay
 
-V1 ships immediate commands for pane and tab cycling:
-
-- `Ctrl+Tab` / `Ctrl+Shift+Tab` move through tabs in visual order inside the focused pane
-- `Ctrl+Alt+Tab` / `Ctrl+Alt+Shift+Tab` cycle MRU panes
-
-V2 should upgrade this to a real switcher session instead of firing the command on every `keydown`.
+V2 should add a visual switcher overlay on top of the existing MRU cycling session mechanism.
 
 Requirements:
 
-- Holding the modifier should open a transient switcher overlay showing recent tabs for the focused pane
-- Repeated `Tab` presses should advance selection inside the overlay without committing immediately
+- Holding the modifier should open a transient switcher overlay showing the frozen MRU list
+- The overlay should highlight the currently selected entry as the user cycles
 - Releasing the modifier should commit the selected target and close the overlay
-- A parallel pane switcher should exist for pane MRU, not just tab MRU
 - The overlay should show enough metadata to disambiguate duplicates: tab title, pane type/icon, and path when relevant
 
 Implementation notes:
 
-- Extend the keybinding/input layer beyond `keydown` only. The current keybinding service does not model `keyup`, modifier-hold sessions, or transient navigation state.
-- Add a small switcher controller in the renderer that can start, advance, reverse, cancel, and commit a navigation session.
-- Keep MRU tracking in the Dockview navigation service; the V2 switcher should consume that state instead of building its own history model.
+- The cycling session logic already exists in `DockviewNavigation` (`isCycling`, `endCyclingSession`). The overlay should consume this state.
 - Suppress switcher activation while modal text inputs are focused, unless the focused surface explicitly opts in.
 - Prefer a generic switcher primitive so the same mechanism can later power workspace MRU switching if desired.
 

--- a/packages/renderer/src/lib/dockviewNavigation.ts
+++ b/packages/renderer/src/lib/dockviewNavigation.ts
@@ -41,6 +41,15 @@ export class DockviewNavigation {
   private paneHistory: string[] = []
   private tabHistoryByPane = new Map<string, string[]>()
 
+  private cycling: {
+    type: 'pane' | 'tab'
+    frozenOrder: string[]
+    index: number
+    paneId?: string // for tab cycling: which pane's tabs are being cycled
+  } | null = null
+  private suppressActivation = false
+  private keyUpHandler: ((e: KeyboardEvent) => void) | null = null
+
   constructor(private readonly api: DockviewApi) {
     for (const panel of api.panels) {
       this.ensurePane(panel)
@@ -50,7 +59,7 @@ export class DockviewNavigation {
     }
 
     api.onDidActivePanelChange((panel) => {
-      if (panel) this.recordActivation(panel)
+      if (panel && !this.suppressActivation) this.recordActivation(panel)
     })
 
     api.onDidRemovePanel((panel) => {
@@ -58,15 +67,31 @@ export class DockviewNavigation {
     })
   }
 
+  get isCycling(): boolean {
+    return this.cycling !== null
+  }
+
   focusPaneRecent(direction: 1 | -1): boolean {
-    const currentPaneId = getPaneId(this.api.activePanel)
-    if (!currentPaneId) return false
+    if (this.cycling && this.cycling.type === 'tab') {
+      this.endCyclingSession()
+    }
 
-    const orderedPaneIds = this.getPaneIdsInRecentOrder()
-    const targetPaneId = direction === 1
-      ? orderedPaneIds.find((paneId) => paneId !== currentPaneId) ?? null
-      : [...orderedPaneIds].reverse().find((paneId) => paneId !== currentPaneId) ?? null
+    if (!this.cycling) {
+      const currentPaneId = getPaneId(this.api.activePanel)
+      if (!currentPaneId) return false
 
+      const frozenOrder = this.getPaneIdsInRecentOrder()
+      if (frozenOrder.length <= 1) return false
+
+      const index = frozenOrder.indexOf(currentPaneId)
+      this.cycling = { type: 'pane', frozenOrder, index: index === -1 ? 0 : index }
+      this.suppressActivation = true
+      this.installKeyUpListener()
+    }
+
+    const { frozenOrder } = this.cycling
+    this.cycling.index = (this.cycling.index + direction + frozenOrder.length) % frozenOrder.length
+    const targetPaneId = frozenOrder[this.cycling.index]
     if (!targetPaneId) return false
     return this.focusPane(targetPaneId)
   }
@@ -82,18 +107,30 @@ export class DockviewNavigation {
   }
 
   focusTabRecent(direction: 1 | -1): boolean {
-    const activePanel = this.api.activePanel
-    const paneId = getPaneId(activePanel)
-    if (!activePanel || !paneId) return false
+    if (this.cycling && this.cycling.type === 'pane') {
+      this.endCyclingSession()
+    }
 
-    const panePanels = getPanePanels(activePanel)
-    if (panePanels.length <= 1) return false
+    if (!this.cycling) {
+      const activePanel = this.api.activePanel
+      const paneId = getPaneId(activePanel)
+      if (!activePanel || !paneId) return false
 
-    const history = this.getTabIdsInRecentOrder(paneId, panePanels)
-    const targetPanelId = direction === 1
-      ? history.find((panelId) => panelId !== activePanel.id) ?? null
-      : [...history].reverse().find((panelId) => panelId !== activePanel.id) ?? null
+      const panePanels = getPanePanels(activePanel)
+      if (panePanels.length <= 1) return false
 
+      const frozenOrder = this.getTabIdsInRecentOrder(paneId, panePanels)
+      if (frozenOrder.length <= 1) return false
+
+      const index = frozenOrder.indexOf(activePanel.id)
+      this.cycling = { type: 'tab', frozenOrder, index: index === -1 ? 0 : index, paneId }
+      this.suppressActivation = true
+      this.installKeyUpListener()
+    }
+
+    const { frozenOrder } = this.cycling
+    this.cycling.index = (this.cycling.index + direction + frozenOrder.length) % frozenOrder.length
+    const targetPanelId = frozenOrder[this.cycling.index]
     if (!targetPanelId) return false
     return this.focusPanelById(targetPanelId)
   }
@@ -108,6 +145,43 @@ export class DockviewNavigation {
 
     targetPanel.api.setActive()
     return true
+  }
+
+  endCyclingSession(): void {
+    if (!this.cycling) return
+
+    this.removeKeyUpListener()
+    this.cycling = null
+    this.suppressActivation = false
+
+    // Commit the now-active panel into MRU history
+    const activePanel = this.api.activePanel
+    if (activePanel) {
+      this.recordActivation(activePanel)
+    }
+  }
+
+  dispose(): void {
+    this.removeKeyUpListener()
+  }
+
+  private installKeyUpListener(): void {
+    if (this.keyUpHandler) return
+
+    this.keyUpHandler = (e: KeyboardEvent) => {
+      // End cycling when any modifier key is released
+      if (e.key === 'Control' || e.key === 'Alt' || e.key === 'Meta') {
+        this.endCyclingSession()
+      }
+    }
+    window.addEventListener('keyup', this.keyUpHandler, true)
+  }
+
+  private removeKeyUpListener(): void {
+    if (this.keyUpHandler) {
+      window.removeEventListener('keyup', this.keyUpHandler, true)
+      this.keyUpHandler = null
+    }
   }
 
   private ensurePane(panel: DockviewPanel): void {


### PR DESCRIPTION
## Summary

- Replaces the toggle-most-recent (ping-pong) behavior in `focusPaneRecent` and `focusTabRecent` with VS Code-style MRU cycling sessions
- On first cycle keystroke: freezes MRU order by suppressing `recordActivation`, installs a global `keyup` listener
- On subsequent keystrokes (while modifier held): walks through the frozen MRU list in order
- On modifier key-up (Ctrl/Alt/Meta): commits selection, updates MRU history, removes listener
- Updated `IDE_BUILD_PLAN.md` to document the new cycling session mechanism and refine the V2 overlay plan

Closes #20

## Test plan

- [ ] Open 3+ panes, use `Ctrl+Alt+Tab` repeatedly while holding Ctrl+Alt — should cycle through all panes in MRU order (not just toggle between two)
- [ ] Release Ctrl/Alt — selection commits, next cycle starts fresh with updated MRU
- [ ] Open 3+ tabs in a single pane, use tab MRU cycling — same behavior within the pane
- [ ] Verify that switching between pane cycling and tab cycling mid-session correctly ends the previous session
- [ ] Verify `dispose()` cleans up the keyup listener

https://claude.ai/code/session_015R22KqrqjKdj8xEST5RvKW

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Refined pane and tab cycling with improved Most Recently Used (MRU) order management during active cycling sessions for more responsive navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->