### PR TITLE
fix: comment blank lines in selections and tighten ResolvedSettings indexing

### DIFF
--- a/packages/renderer/src/hooks/useSettings.ts
+++ b/packages/renderer/src/hooks/useSettings.ts
@@ -99,7 +99,7 @@ export function useSettings(): UseSettingsReturn {
 
   const getEffectiveValue = useCallback((key: string): unknown => {
     if (!resolved) return undefined
-    return (resolved as Record<string, unknown>)[key]
+    return resolved[key as keyof ResolvedSettings]
   }, [resolved])
 
   const getScopeValue = useCallback((key: string): unknown => {
@@ -109,7 +109,7 @@ export function useSettings(): UseSettingsReturn {
     if (val !== undefined) return val
     // Fall back to resolved (effective) value for display
     if (!resolved) return undefined
-    return (resolved as Record<string, unknown>)[key]
+    return resolved[key as keyof ResolvedSettings]
   }, [scope, userSettings, workspaceSettings, resolved])
 
   return {

--- a/packages/renderer/src/lib/editorComments.ts
+++ b/packages/renderer/src/lib/editorComments.ts
@@ -64,9 +64,9 @@ function updateLineCommentsInActiveEditor(mode: CommentMode): CommentResult {
 
   for (let i = lines.length - 1; i >= 0; i--) {
     const line = lines[i]
-    if (line.text.trim().length === 0) continue
 
-    const indent = line.text.match(/^\s*/)?.[0].length ?? 0
+    const isBlank = line.text.trim().length === 0
+    const indent = isBlank ? 0 : line.text.match(/^\s*/)?.[0].length ?? 0
     const offset = line.from + indent
 
     if (shouldUncomment && line.text.slice(indent).startsWith(token)) {


### PR DESCRIPTION
### Motivation
- Fix GitHub #21 so toggling line comments (`Cmd+/`) on mixed multi-line selections also comments blank lines for a uniform visual block.
- Fix GitHub #15 by addressing two unsafe TypeScript index operations on `resolved` to be type-safe with `ResolvedSettings` keys.

### Description
- In `packages/renderer/src/lib/editorComments.ts` removed the early `continue` that skipped blank lines and compute `indent` as `0` for blank lines so the line comment token is inserted at column 0 for blank lines while preserving non-blank behavior.
- Kept the existing early-return for fully blank selections (`if (nonBlankLines.length === 0) return 'ok'`).
- In `packages/renderer/src/hooks/useSettings.ts` replaced `(resolved as Record<string, unknown>)[key]` with `resolved[key as keyof ResolvedSettings]` at `getEffectiveValue` and `getScopeValue` to tighten typing.
- Changes committed with the `fix:` prefix and localized to the two files above; `IDE_BUILD_PLAN.md` was not modified.

### Testing
- Ran `npx tsc --noEmit` from `packages/renderer`; the command was executed but typecheck still fails due to many pre-existing repository TypeScript errors (e.g. `TS6305` related to shared package artifacts and existing implicit-`any` issues), none introduced by these edits.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7d8961f588330b60380864fdc5995)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of blank lines when adding or removing comments in the editor.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->