### PR TITLE
fix: use type-safe ResolvedSettings key access in useSettings

### DIFF
--- a/packages/renderer/src/hooks/useSettings.ts
+++ b/packages/renderer/src/hooks/useSettings.ts
@@ -99,7 +99,7 @@ export function useSettings(): UseSettingsReturn {
 
   const getEffectiveValue = useCallback((key: string): unknown => {
     if (!resolved) return undefined
-    return (resolved as Record<string, unknown>)[key]
+    return resolved[key as keyof ResolvedSettings]
   }, [resolved])
 
   const getScopeValue = useCallback((key: string): unknown => {
@@ -109,7 +109,7 @@ export function useSettings(): UseSettingsReturn {
     if (val !== undefined) return val
     // Fall back to resolved (effective) value for display
     if (!resolved) return undefined
-    return (resolved as Record<string, unknown>)[key]
+    return resolved[key as keyof ResolvedSettings]
   }, [scope, userSettings, workspaceSettings, resolved])
 
   return {


### PR DESCRIPTION
### Motivation
- Stop unsafe casts that produced TS2352 errors when indexing `ResolvedSettings` with dynamic keys.

### Description
- Replace two instances of `(resolved as Record<string, unknown>)[key]` with `resolved[key as keyof ResolvedSettings]` in `packages/renderer/src/hooks/useSettings.ts`; `ResolvedSettings` was already imported so no import changes were needed.

### Testing
- Ran `npx tsc --noEmit` in `packages/renderer`; the two TS2352 errors in `useSettings.ts` are fixed, but the full renderer typecheck still fails due to unrelated pre-existing errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7d8b78758833082bcc7a9453f3478)