### PR TITLE
Fix renderer ESLint: hook-order, missing dependency, and unused variables

### DIFF
--- a/packages/renderer/src/components/panes/EditorPane.tsx
+++ b/packages/renderer/src/components/panes/EditorPane.tsx
@@ -16,7 +16,7 @@ import { setContext } from '../../lib/ContextKeys'
 import { useEditorStatus } from '../../hooks/useEditorStatus'
 import { useTheme } from '../../hooks/useTheme'
 import { showToast } from '../Toast'
-import { diffCompartment, toggleInlineDiff, isInlineDiffActive } from '../../lib/editorInlineDiff'
+import { diffCompartment, toggleInlineDiff } from '../../lib/editorInlineDiff'
 import '../../styles/inline-diff.css'
 
 interface EditorPaneParams {
@@ -254,7 +254,7 @@ export function EditorPane({ params, api }: IDockviewPanelProps<EditorPaneParams
       clearContent(filePath)
       cleanContentMap.delete(filePath)
     }
-  }, [filePath])
+  }, [filePath, toggleInlineDiffForView])
 
   /**
    * Replace the editor's document with the file's current disk contents.
@@ -400,6 +400,12 @@ export function EditorPane({ params, api }: IDockviewPanelProps<EditorPaneParams
     return () => disposable.dispose()
   }, [api, filePath, setStatus])
 
+  const handleDiffBadgeClick = useCallback(() => {
+    const view = viewRef.current
+    if (!view) return
+    void toggleInlineDiffForView(view)
+  }, [toggleInlineDiffForView])
+
   if (error) {
     return (
       <div className="editor-pane">
@@ -407,12 +413,6 @@ export function EditorPane({ params, api }: IDockviewPanelProps<EditorPaneParams
       </div>
     )
   }
-
-  const handleDiffBadgeClick = useCallback(() => {
-    const view = viewRef.current
-    if (!view) return
-    void toggleInlineDiffForView(view)
-  }, [toggleInlineDiffForView])
 
   return (
     <div className="editor-pane">

--- a/packages/renderer/src/components/settings/KeyboardShortcutsTable.tsx
+++ b/packages/renderer/src/components/settings/KeyboardShortcutsTable.tsx
@@ -26,7 +26,7 @@ export function KeyboardShortcutsTable() {
     const rules = getAllKeybindingRules()
 
     // Build rows from keybinding rules
-    const ruleRows: ShortcutRow[] = rules.map((entry, _index) => {
+    const ruleRows: ShortcutRow[] = rules.map((entry) => {
       const cmd = commandMap.get(entry.rule.command)
       // Determine override index: find this rule in the user overrides array
       let overrideIndex = -1


### PR DESCRIPTION
### Motivation
- Address ESLint-reported issues in the renderer that could cause a Hooks violation and flag unused symbols.
- Prevent potential React runtime bugs by ensuring hooks are invoked unconditionally and effect dependencies are correct.
- Clean up small dead code to satisfy lint rules for the touched files.

### Description
- Move the `handleDiffBadgeClick` `useCallback` above the early `if (error) return` so hooks are always called in the same order and remove the conditional hook usage. (`packages/renderer/src/components/panes/EditorPane.tsx`)
- Add `toggleInlineDiffForView` to the editor initialization effect dependency array to avoid stale closures. (`packages/renderer/src/components/panes/EditorPane.tsx`)
- Remove the unused `isInlineDiffActive` import from `EditorPane`. (`packages/renderer/src/components/panes/EditorPane.tsx`)
- Remove the unused `_index` parameter from the `rules.map(...)` callback in `KeyboardShortcutsTable`. (`packages/renderer/src/components/settings/KeyboardShortcutsTable.tsx`)

### Testing
- Ran `pnpm eslint packages/renderer/src/components/panes/EditorPane.tsx packages/renderer/src/components/settings/KeyboardShortcutsTable.tsx` and it completed successfully.
- Ran full lint `pnpm lint` which still fails due to pre-existing errors outside the modified files (errors remain in `packages/main/src/index.ts`, `packages/renderer/src/components/settings/SettingsCategorySidebar.tsx`, and `packages/renderer/src/hooks/useSettings.ts`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c8010690e0833096df32dc79b626bf)