### PR TITLE
Fix settings lint issues (no-dynamic-delete and non-null assertions)

### DIFF
--- a/packages/main/src/index.ts
+++ b/packages/main/src/index.ts
@@ -524,9 +524,11 @@ ipcMain.handle(IpcChannels.SETTINGS_GET_USER, () => {
 })
 
 ipcMain.handle(IpcChannels.SETTINGS_SET_USER, async (_event, key: string, value: unknown) => {
-  const current = (store.get('editorDefaults') ?? {}) as Record<string, unknown>
+  let current = (store.get('editorDefaults') ?? {}) as Record<string, unknown>
   if (value === undefined || value === null) {
-    delete current[key]
+    current = Object.fromEntries(
+      Object.entries(current).filter(([entryKey]) => entryKey !== key),
+    )
   } else {
     current[key] = value
   }
@@ -575,7 +577,9 @@ ipcMain.handle(IpcChannels.SETTINGS_SET_WORKSPACE, async (_event, key: string, v
   }
 
   if (value === undefined || value === null) {
-    delete current[key]
+    current = Object.fromEntries(
+      Object.entries(current).filter(([entryKey]) => entryKey !== key),
+    )
   } else {
     current[key] = value
   }

--- a/packages/renderer/src/components/settings/SettingsCategorySidebar.tsx
+++ b/packages/renderer/src/components/settings/SettingsCategorySidebar.tsx
@@ -40,15 +40,16 @@ interface CategoryItemProps {
 
 function CategoryItem({ category, activeCategory, onSelect, categoriesWithSettings, depth }: CategoryItemProps) {
   const [expanded, setExpanded] = useState(true)
-  const hasChildren = category.children && category.children.length > 0
+  const children = category.children ?? []
+  const hasChildren = children.length > 0
   const isActive = activeCategory === category.id
-  const isParentActive = hasChildren && category.children!.some(
+  const isParentActive = hasChildren && children.some(
     (c) => c.id === activeCategory,
   )
 
   // Check if this category or any children have settings
   const hasSettings = categoriesWithSettings.has(category.id) || (
-    hasChildren && category.children!.some((c) => categoriesWithSettings.has(c.id))
+    hasChildren && children.some((c) => categoriesWithSettings.has(c.id))
   )
 
   return (
@@ -60,8 +61,9 @@ function CategoryItem({ category, activeCategory, onSelect, categoriesWithSettin
           if (hasChildren) {
             setExpanded(!expanded)
             // Select first child if clicking parent
-            if (!expanded && category.children![0]) {
-              onSelect(category.children![0].id)
+            const firstChild = children[0]
+            if (!expanded && firstChild) {
+              onSelect(firstChild.id)
             }
           } else {
             onSelect(category.id)
@@ -77,7 +79,7 @@ function CategoryItem({ category, activeCategory, onSelect, categoriesWithSettin
       </button>
       {hasChildren && expanded && (
         <div className="settings-sidebar__children">
-          {category.children!.map((child) => (
+          {children.map((child) => (
             <CategoryItem
               key={child.id}
               category={child}

--- a/packages/renderer/src/hooks/useSettings.ts
+++ b/packages/renderer/src/hooks/useSettings.ts
@@ -74,16 +74,18 @@ export function useSettings(): UseSettingsReturn {
     if (scope === 'user') {
       setUserSettings((prev) => {
         if (!prev) return prev
-        const next = { ...prev }
-        delete (next as Record<string, unknown>)[key]
+        const next = Object.fromEntries(
+          Object.entries(prev as Record<string, unknown>).filter(([entryKey]) => entryKey !== key),
+        )
         return next
       })
       await window.api.setUserSetting(key, undefined)
     } else {
       setWorkspaceSettings((prev) => {
         if (!prev) return prev
-        const next = { ...prev }
-        delete (next as Record<string, unknown>)[key]
+        const next = Object.fromEntries(
+          Object.entries(prev as Record<string, unknown>).filter(([entryKey]) => entryKey !== key),
+        )
         return next
       })
       await window.api.setWorkspaceSetting(key, undefined)


### PR DESCRIPTION
### Motivation
- Resolve several LOW-severity lint findings by removing dynamic `delete` operations and non-null assertions in settings-related code to satisfy style rules without changing runtime behavior.
- Make optimistic updates and sidebar rendering safer by avoiding mutating/deleting object properties and using explicit safe access for optional children.

### Description
- Replace dynamic `delete current[key]` in main process settings handlers with immutable key-removal using `Object.entries(...).filter(...)` + `Object.fromEntries(...)` for both user and workspace updates in `packages/main/src/index.ts`.
- Update `resetToDefault` in `packages/renderer/src/hooks/useSettings.ts` to remove keys immutably when performing optimistic state updates.
- Refactor `packages/renderer/src/components/settings/SettingsCategorySidebar.tsx` to normalize `children` to an empty array, remove non-null assertions, and safely select the first child when expanding a parent category.
- All changes are stylistic/lint-focused and do not alter external behavior or persisted formats.

### Testing
- Ran ESLint on the modified files with `pnpm exec eslint packages/main/src/index.ts packages/renderer/src/hooks/useSettings.ts packages/renderer/src/components/settings/SettingsCategorySidebar.tsx`, and the lint run passed with no errors.
- No other automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c8015543b483308e19183516d93586)